### PR TITLE
VHIOPS-59, VHI Admin Panel shortcut for Bastion

### DIFF
--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -22,6 +22,16 @@ useradd -m -s /bin/bash -G sudo student
 # Set the password for the "student" user
 usermod --password "${PASSWORD_HASH}" student
 
+# Create a URL shortcut for VHI Admin Panel
+mkdir -p /home/student/Desktop
+echo "[Desktop Entry]
+Encoding=UTF-8
+Name=VHI Admin Panel
+Type=Link
+URL=https://cloud.student.lab:8888
+Icon=text-html" > "/home/student/Desktop/VHI Admin Panel.desktop"
+chown -R student:student /home/student/Desktop
+
 # Install the Cinnamon desktop environment and XRDP
 DEBIAN_FRONTEND=noninteractive apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y cinnamon-desktop-environment cinnamon-core xrdp

--- a/cloud-init/node.sh
+++ b/cloud-init/node.sh
@@ -391,6 +391,9 @@ else
     # Join the storage cluster
     node_id=`hostname`
     log_msg "Joining the storage cluster..."
-    retry sshpass -p ${password_root} ssh -o 'StrictHostKeyChecking=no' -o LogLevel=QUIET root@${mn_ip} "vinfra --vinfra-password ${password_admin} node join $node_id --wait"
+    retry sshpass -p ${password_root} ssh -o 'StrictHostKeyChecking=no' -o LogLevel=QUIET root@${mn_ip} \
+      "vinfra --vinfra-password ${password_admin} node join \
+      --disk sda:mds-system --disk sdb:cs:tier=0,journal-type=inner_cache \
+      $node_id --wait"
     log_msg "Joining the storage cluster...done"
 fi

--- a/cloud-init/node.sh
+++ b/cloud-init/node.sh
@@ -378,7 +378,7 @@ else
     assign_iface eth1 Private
     assign_iface eth2 Public
     assign_iface eth3 VM_Public
-    log_msg "Waiting 15 seconds for for DB to update"
+    log_msg "Waiting 15 seconds for DB to update"
 
     # Check that storage cluster is present
     until vinfra --vinfra-password ${password_admin} cluster show | grep -q "name.*${cluster_name}"
@@ -386,7 +386,7 @@ else
     log_msg "Waiting for storage cluster to initialize..."
     sleep 10
     done
-    log_msg "Waiting for storage cluster to initialize..done"
+    log_msg "Waiting for storage cluster to initialize...done"
 
     # Join the storage cluster
     node_id=`hostname`


### PR DESCRIPTION
— VHIOPS-59: make sdc unassigned by default on non-main nodes
— Added a shortcut to VHI Admin Panel on Bastion desktop
— Minor typo fixes